### PR TITLE
Kratos email templates

### DIFF
--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -9,6 +9,11 @@ type Mutation {
   ): UserWithRole!
 }
 
+enum Language {
+  en
+  de
+}
+
 enum UserRole {
   junior
   intermediate
@@ -22,5 +27,6 @@ type UserWithRole {
   username: String!
   email: String!
   role: UserRole!
+  lang: Language!
 }
 

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -27,6 +27,14 @@ actions:
     comment: Update user role
 custom_types:
   enums:
+    - name: Language
+      values:
+        - description: null
+          is_deprecated: null
+          value: en
+        - description: null
+          is_deprecated: null
+          value: de
     - name: UserRole
       values:
         - description: null

--- a/kratos/Dockerfile.kratos
+++ b/kratos/Dockerfile.kratos
@@ -7,5 +7,6 @@ RUN mkdir -p /etc/config/kratos
 COPY jsonnet /etc/config/kratos/jsonnet
 COPY identity.schema.json /etc/config/kratos/identity.schema.json
 COPY kratos.yml /etc/config/kratos/kratos.yml
+COPY templates /etc/config/kratos/templates
 USER ory
 ENTRYPOINT [kratos]

--- a/kratos/identity.schema.json
+++ b/kratos/identity.schema.json
@@ -60,6 +60,15 @@
             "junior"
           ]
         },
+        "lang": {
+          "title": "Language",
+          "type": "string",
+          "default": "de",
+          "enum": [
+            "en",
+            "de"
+          ]
+        },
         "additionalProperties": false
       }
     }

--- a/kratos/kratos.yml
+++ b/kratos/kratos.yml
@@ -124,6 +124,14 @@ identity:
 courier:
   smtp:
     connection_uri: smtps://test:test@mailslurper:1025/?skip_ssl_verify=true
+  templates:
+    verification_code:
+      valid:
+        email:
+          body:
+            html: file:///etc/config/kratos/templates/verification_code_valid_email_body.html.gotmpl
+            plaintext: file:///etc/config/kratos/templates/verification_code_valid_email_body.plaintext.gotmpl
+          subject: file:///etc/config/kratos/templates/verification_code_valid_email_subject.gotmpl
 
 feature_flags:
   use_continue_with_transitions: true

--- a/kratos/templates/verification_code_valid_email_body.html.gotmpl
+++ b/kratos/templates/verification_code_valid_email_body.html.gotmpl
@@ -1,0 +1,21 @@
+{{define "en"}}
+    <h4>Welcome to Faktenforum, a way to debunk fake news - as a community.</h4>
+    <p>
+        To finish your registration, please enter the code "{{ .VerificationCode }}" or open the
+        following link: <a href="{{ .VerificationURL }}">{{ .VerificationURL }}</a>
+    </p>
+{{end}}
+
+{{define "de"}}
+    <h4>Willkommen beim Faktenforum, der Weg um Faktenews aufzudecken - als eine Community.</h4>
+    <p>
+        Um deine Registrierung abzuschließen, gib bitten diesen Code ein "{{ .VerificationCode }}"
+        oder fole diesem Link: <a href="{{ .VerificationURL }}">{{ .VerificationURL }}</a>
+    </p>
+{{end}}
+
+{{- if eq .Identity.metadata_public.lang "en" -}}
+    {{ template "en" . }}
+{{- else -}}
+    {{ template "de" . }}
+{{- end -}}

--- a/kratos/templates/verification_code_valid_email_body.plaintext.gotmpl
+++ b/kratos/templates/verification_code_valid_email_body.plaintext.gotmpl
@@ -1,0 +1,17 @@
+{{define "en"}}
+    Welcome to Faktenforum, a way to debunk fake news - as a community.
+
+    To finish your registration, please enter the code "{{ .VerificationCode }}" or visiting: {{ .VerificationURL }}
+{{end}}
+
+{{define "de"}}
+    Willkommen beim Faktenforum, der Weg um Faktenews aufzudecken - als eine Community.
+
+    Um deine Registrierung abzuschließen, gib bitten diesen Code ein "{{ .VerificationCode }}" oder besuche {{ .VerificationURL }}
+{{end}}
+
+{{- if eq .Identity.metadata_public.lang "en" -}}
+    {{ template "en" . }}
+{{- else -}}
+    {{ template "de" . }}
+{{- end -}}

--- a/kratos/templates/verification_code_valid_email_subject.gotmpl
+++ b/kratos/templates/verification_code_valid_email_subject.gotmpl
@@ -1,0 +1,13 @@
+{{define "en"}}
+    Welcome to Faktenforum
+{{end}}
+
+{{define "de"}}
+    Willkommen beim Faktenforum
+{{end}}
+
+{{- if eq .Identity.metadata_public.lang "en" -}}
+    {{ template "en" . }}
+{{- else -}}
+    {{ template "de" . }}
+{{- end -}}

--- a/src/controllers/api/v1/webhooks.ts
+++ b/src/controllers/api/v1/webhooks.ts
@@ -82,7 +82,8 @@ export class WebHookController {
       id: user.id,
       email: user.traits.email,
       username: user.traits.username,
-      role: user.metadata_public.role
+      role: user.metadata_public.role,
+      lang: user.metadata_public.lang ?? DEFAULT_LANGUAGE
     };
   }
 

--- a/src/controllers/api/v1/webhooks.ts
+++ b/src/controllers/api/v1/webhooks.ts
@@ -7,6 +7,8 @@ import { UpdateUserRoleRequest } from "~/models/requests/UpdateUserRoleRequest";
 import { KratosUserSchema } from "~/models/responses/KratosUserSchema";
 import { AuthService, FileService, UsersService, HasuraService, KratosUser } from "~/services";
 
+const DEFAULT_LANGUAGE = "de";
+
 @Controller("/webhooks")
 export class WebHookController {
   @Inject(UsersService)
@@ -60,7 +62,8 @@ export class WebHookController {
     return {
       identity: {
         metadata_public: {
-          role: "junior"
+          role: "junior",
+          lang: DEFAULT_LANGUAGE // TODO take from language selector on the page, once it exists
         }
       }
     };

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -4339,6 +4339,11 @@ export type IntComparisonExp = {
   _nin?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
+export enum Language {
+  De = 'de',
+  En = 'en'
+}
+
 /** column ordering options */
 export enum OrderBy {
   /** in ascending order, nulls last */
@@ -7576,6 +7581,7 @@ export type UserWithRole = {
   __typename?: 'UserWithRole';
   email: Scalars['String']['output'];
   id: Scalars['String']['output'];
+  lang: Language;
   role: UserRole;
   username: Scalars['String']['output'];
 };

--- a/src/models/responses/KratosUserSchema.ts
+++ b/src/models/responses/KratosUserSchema.ts
@@ -16,4 +16,8 @@ export class KratosUserSchema {
   @Property()
   @Required()
   role: string;
+
+  @Property()
+  @Required()
+  lang: string;
 }

--- a/src/services/1_AuthService.ts
+++ b/src/services/1_AuthService.ts
@@ -27,6 +27,11 @@ export enum KratosRole {
   admin = "admin"
 }
 
+export enum KratosLang {
+  de = "de",
+  en = "en"
+}
+
 export type KratosUser = {
   id: "fa4c3f21-ee87-4196-ac70-e9c401ac166b";
   schema_id: string;
@@ -41,6 +46,7 @@ export type KratosUser = {
   recovery_addresses: KratosAddress[];
   metadata_public: {
     role: KratosRole;
+    lang?: KratosLang;
   };
   metadata_admin: null | unknown;
   created_at: string;


### PR DESCRIPTION
Dieser Branch baut auf `all-users-with-roles` auf um die ausgewählte Sprache auch im GraphQL verfügbar zu machen. Bisher gibt es zwar noch keinen Language selector, aber der ist bestimmt geplant.

Die Sprache (`metadata_public.lang` in Kratos) wird leider noch nicht gespeichert (der default Wert sollve verwendet werden, entweder aus dem schema, oder aus dem webhook). Für hinweise warum das nicht funktioniert bin ich dankbar :pray: 

Das templating an sich funktioniert. Bisher ist es nur für die verifizierungs Mail implementiert, als POC